### PR TITLE
Add self-hosted counter.dev analytics

### DIFF
--- a/backend/routes/frontend.ts
+++ b/backend/routes/frontend.ts
@@ -396,6 +396,8 @@ async function renderCheckinPage(
 
         <!-- Load React app -->
         <script type="module" src="${bundleSrc}"></script>
+        <!-- Counter.dev analytics -->
+        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter-tijs.zocomputer.io/track?"+new URLSearchParams({site:"tijs",utcoffset:"1",referrer:document.referrer,screen:screen.width+"x"+screen.height}))};sessionStorage.setItem("_swa","1");</script>
       </body>
       </html>`,
     {

--- a/backend/routes/frontend.ts
+++ b/backend/routes/frontend.ts
@@ -397,7 +397,7 @@ async function renderCheckinPage(
         <!-- Load React app -->
         <script type="module" src="${bundleSrc}"></script>
         <!-- Counter.dev analytics -->
-        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.tijs.org/track?"+new URLSearchParams({site:"tijs",utcoffset:"1",referrer:document.referrer,screen:screen.width+"x"+screen.height}))};sessionStorage.setItem("_swa","1");</script>
+        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.tijs.org/track?"+new URLSearchParams({site:"tijs",utcoffset:String(-(new Date().getTimezoneOffset()/60)),referrer:document.referrer,screen:screen.width+"x"+screen.height}))};sessionStorage.setItem("_swa","1");</script>
       </body>
       </html>`,
     {

--- a/backend/routes/frontend.ts
+++ b/backend/routes/frontend.ts
@@ -397,7 +397,7 @@ async function renderCheckinPage(
         <!-- Load React app -->
         <script type="module" src="${bundleSrc}"></script>
         <!-- Counter.dev analytics -->
-        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter-tijs.zocomputer.io/track?"+new URLSearchParams({site:"tijs",utcoffset:"1",referrer:document.referrer,screen:screen.width+"x"+screen.height}))};sessionStorage.setItem("_swa","1");</script>
+        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.tijs.org/track?"+new URLSearchParams({site:"tijs",utcoffset:"1",referrer:document.referrer,screen:screen.width+"x"+screen.height}))};sessionStorage.setItem("_swa","1");</script>
       </body>
       </html>`,
     {

--- a/backend/routes/frontend.ts
+++ b/backend/routes/frontend.ts
@@ -397,7 +397,7 @@ async function renderCheckinPage(
         <!-- Load React app -->
         <script type="module" src="${bundleSrc}"></script>
         <!-- Counter.dev analytics -->
-        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.tijs.org/track?"+new URLSearchParams({site:"tijs",utcoffset:String(-(new Date().getTimezoneOffset()/60)),referrer:document.referrer,screen:screen.width+"x"+screen.height})).catch(function(){})};sessionStorage.setItem("_swa","1");</script>
+        <script>try{if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!==0){fetch("https://counter.tijs.org/track?"+new URLSearchParams({site:"tijs",utcoffset:String(-(new Date().getTimezoneOffset()/60)),referrer:document.referrer,screen:screen.width+"x"+screen.height})).catch(function(){})};sessionStorage.setItem("_swa","1")}catch(e){}</script>
       </body>
       </html>`,
     {

--- a/backend/routes/frontend.ts
+++ b/backend/routes/frontend.ts
@@ -397,7 +397,7 @@ async function renderCheckinPage(
         <!-- Load React app -->
         <script type="module" src="${bundleSrc}"></script>
         <!-- Counter.dev analytics -->
-        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.tijs.org/track?"+new URLSearchParams({site:"tijs",utcoffset:String(-(new Date().getTimezoneOffset()/60)),referrer:document.referrer,screen:screen.width+"x"+screen.height}))};sessionStorage.setItem("_swa","1");</script>
+        <script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.tijs.org/track?"+new URLSearchParams({site:"tijs",utcoffset:String(-(new Date().getTimezoneOffset()/60)),referrer:document.referrer,screen:screen.width+"x"+screen.height})).catch(function(){})};sessionStorage.setItem("_swa","1");</script>
       </body>
       </html>`,
     {

--- a/frontend/components/PrivacyPolicy.tsx
+++ b/frontend/components/PrivacyPolicy.tsx
@@ -163,8 +163,16 @@ export function PrivacyPolicy() {
               Encrypted authentication tokens to keep you logged in
             </li>
             <li className={listItemStyle}>
-              <strong>Error logs:</strong>{" "}
-              Technical logs for debugging (no personal location data)
+              <strong>Interaction indexes:</strong>{" "}
+              Counts and references for likes and comments on check-ins,
+              enabling efficient discovery. The actual like and comment records
+              live on users' PDS.
+            </li>
+            <li className={listItemStyle}>
+              <strong>Error tracking:</strong>{" "}
+              We use Sentry to monitor application errors. Error reports may
+              include technical context (browser, URL, stack trace) but never
+              include your location data or check-in content.
             </li>
           </ul>
 
@@ -234,10 +242,62 @@ export function PrivacyPolicy() {
               For venue search and location enrichment
             </li>
             <li className={listItemStyle}>
-              <strong>Val Town:</strong>{" "}
+              <strong>Sentry:</strong>{" "}
+              For error tracking and application monitoring
+            </li>
+            <li className={listItemStyle}>
+              <strong>Deno Deploy:</strong>{" "}
               Our hosting platform for the web service
             </li>
           </ul>
+        </section>
+
+        <section className={sectionStyle}>
+          <h2 className={sectionTitleStyle}>Analytics</h2>
+          <p className={paragraphStyle}>
+            Anchor uses a self-hosted, privacy-friendly analytics service
+            (counter.dev) to understand how the site is used. This service:
+          </p>
+          <ul className={listStyle}>
+            <li className={listItemStyle}>
+              Does <strong>not</strong>{" "}
+              use cookies or local storage for tracking
+            </li>
+            <li className={listItemStyle}>
+              Does <strong>not</strong> collect or store IP addresses
+            </li>
+            <li className={listItemStyle}>
+              Does <strong>not</strong> fingerprint browsers or devices
+            </li>
+            <li className={listItemStyle}>
+              Does <strong>not</strong> track individual users across sessions
+            </li>
+          </ul>
+          <p className={paragraphStyle}>
+            On each page visit, the following anonymous data is sent to our
+            self-hosted analytics server:
+          </p>
+          <ul className={listStyle}>
+            <li className={listItemStyle}>
+              <strong>Referrer URL:</strong>{" "}
+              The page that linked you to Anchor (if any)
+            </li>
+            <li className={listItemStyle}>
+              <strong>Screen resolution:</strong>{" "}
+              Your screen width and height (e.g. "1920x1080")
+            </li>
+            <li className={listItemStyle}>
+              <strong>UTC offset:</strong>{" "}
+              Your timezone offset from UTC (e.g. "+2" for Central European
+              Summer Time)
+            </li>
+          </ul>
+          <p className={paragraphStyle}>
+            This data is aggregated into daily visitor counts and cannot be used
+            to identify individual users. The analytics server is self-hosted
+            and operated by us — no data is shared with third-party analytics
+            providers. Only one page view per browser session is counted.
+          </p>
         </section>
 
         <section className={sectionStyle}>

--- a/frontend/components/TermsOfService.tsx
+++ b/frontend/components/TermsOfService.tsx
@@ -335,7 +335,19 @@ export function TermsOfService() {
             <li className={listItemStyle}>
               <strong>Your PDS provider:</strong> For data storage and retrieval
             </li>
+            <li className={listItemStyle}>
+              <strong>Sentry:</strong> For error tracking and monitoring
+            </li>
           </ul>
+          <p className={paragraphStyle}>
+            Anchor also uses self-hosted, cookie-free analytics to count page
+            visits. No personal data or location information is collected by the
+            analytics service. See our{" "}
+            <a href="/privacy-policy" className={linkStyle}>
+              Privacy Policy
+            </a>{" "}
+            for details.
+          </p>
           <p className={paragraphStyle}>
             We are not responsible for the availability, accuracy, or policies
             of these third-party services.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,5 +47,25 @@
       src="https://esm.sh/jsr/@tijs/actor-typeahead@0.2.1"
     ></script>
     <script type="module" src="/static/bundle.js"></script>
+    <!-- Counter.dev analytics -->
+    <script>
+      if (
+        !sessionStorage.getItem("_swa") &&
+        document.referrer.indexOf(
+            location.protocol + "//" + location.host,
+          ) !== 0
+      ) {
+        fetch(
+          "https://counter-tijs.zocomputer.io/track?" +
+            new URLSearchParams({
+              site: "tijs",
+              utcoffset: "1",
+              referrer: document.referrer,
+              screen: screen.width + "x" + screen.height,
+            }),
+        );
+      }
+      sessionStorage.setItem("_swa", "1");
+    </script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,7 +56,7 @@
           ) !== 0
       ) {
         fetch(
-          "https://counter-tijs.zocomputer.io/track?" +
+          "https://counter.tijs.org/track?" +
             new URLSearchParams({
               site: "tijs",
               utcoffset: "1",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -63,7 +63,7 @@
               referrer: document.referrer,
               screen: screen.width + "x" + screen.height,
             }),
-        );
+        ).catch(() => {});
       }
       sessionStorage.setItem("_swa", "1");
     </script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,7 +59,7 @@
           "https://counter.tijs.org/track?" +
             new URLSearchParams({
               site: "tijs",
-              utcoffset: "1",
+              utcoffset: String(-(new Date().getTimezoneOffset() / 60)),
               referrer: document.referrer,
               screen: screen.width + "x" + screen.height,
             }),

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,23 +49,27 @@
     <script type="module" src="/static/bundle.js"></script>
     <!-- Counter.dev analytics -->
     <script>
-      if (
-        !sessionStorage.getItem("_swa") &&
-        document.referrer.indexOf(
-            location.protocol + "//" + location.host,
-          ) !== 0
-      ) {
-        fetch(
-          "https://counter.tijs.org/track?" +
-            new URLSearchParams({
-              site: "tijs",
-              utcoffset: String(-(new Date().getTimezoneOffset() / 60)),
-              referrer: document.referrer,
-              screen: screen.width + "x" + screen.height,
-            }),
-        ).catch(() => {});
-      }
-      sessionStorage.setItem("_swa", "1");
+      try {
+        if (
+          !sessionStorage.getItem("_swa") &&
+          document.referrer.indexOf(
+              location.protocol + "//" + location.host,
+            ) !== 0
+        ) {
+          fetch(
+            "https://counter.tijs.org/track?" +
+              new URLSearchParams({
+                site: "tijs",
+                utcoffset: String(
+                  -(new Date().getTimezoneOffset() / 60),
+                ),
+                referrer: document.referrer,
+                screen: screen.width + "x" + screen.height,
+              }),
+          ).catch(() => {});
+        }
+        sessionStorage.setItem("_swa", "1");
+      } catch (_) {}
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add self-hosted counter.dev analytics tracking to all pages
- Tracking endpoint: `https://counter.tijs.org` (self-hosted instance with custom domain)
- Uses sessionStorage-based deduplication (standard counter.dev pattern)
- Privacy-friendly: no cookies, no fingerprinting, fire-and-forget with `.catch()` to prevent app breakage

## Files changed
- `frontend/index.html` — tracking script for SPA shell
- `backend/routes/frontend.ts` — tracking script for SSR checkin detail pages

## Test plan
- [ ] Verify tracking appears in counter.dev dashboard after page load
- [ ] Verify app loads normally when counter endpoint is unreachable
- [ ] Verify no double-counting on same-session navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)