### PR TITLE
Fix: suppress URIError from malformed URLs

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -21,7 +21,10 @@ Sentry.init({
     // decodeURI() during route matching before middleware can intercept.
     // See: Sentry #102617952.
     const exception = event.exception?.values?.[0];
-    if (exception?.type === "URIError") {
+    if (
+      exception?.type === "URIError" &&
+      exception?.value?.includes("URI malformed")
+    ) {
       return null;
     }
     return event;

--- a/main.ts
+++ b/main.ts
@@ -15,6 +15,17 @@ Sentry.init({
   environment: Deno.env.get("DENO_DEPLOYMENT_ID")
     ? "production"
     : "development",
+  beforeSend(event) {
+    // Drop URIError from malformed URLs (e.g. /%c0). These are caused by bots
+    // and scanners sending invalid percent-encoding. Fresh's router calls
+    // decodeURI() during route matching before middleware can intercept.
+    // See: Sentry #102617952.
+    const exception = event.exception?.values?.[0];
+    if (exception?.type === "URIError") {
+      return null;
+    }
+    return event;
+  },
 });
 
 import { App, staticFiles } from "@fresh/core";
@@ -35,27 +46,11 @@ let app = new App();
 // Middleware
 // ============================================================================
 
-// Reject malformed URIs early — invalid percent-encoding (e.g. /%c0) causes
-// decodeURI to throw inside Fresh's router before middleware can handle it.
-app = app.use(async (ctx) => {
-  try {
-    decodeURI(new URL(ctx.req.url).pathname);
-  } catch {
-    return new Response("Bad Request", { status: 400 });
-  }
-  return await ctx.next();
-});
-
 // Error handling middleware — report to Sentry
 app = app.use(async (ctx) => {
   try {
     return await ctx.next();
   } catch (err) {
-    // Malformed percent-encoding (e.g. /%c0) causes decodeURI to throw
-    // inside Fresh's router. Return 400 instead of crashing. See: Sentry #102617952.
-    if (err instanceof URIError) {
-      return new Response("Bad Request", { status: 400 });
-    }
     Sentry.captureException(err);
     console.error("Unhandled error:", err);
     throw err;

--- a/main.ts
+++ b/main.ts
@@ -46,11 +46,17 @@ let app = new App();
 // Middleware
 // ============================================================================
 
-// Error handling middleware — report to Sentry
+// Error handling middleware — report to Sentry (filter out bot noise)
 app = app.use(async (ctx) => {
   try {
     return await ctx.next();
   } catch (err) {
+    // Fresh throws HttpError(405) when bots POST/PUT/DELETE to GET-only routes
+    // (e.g. the catch-all GET * frontend route). Return a clean 405 without
+    // reporting to Sentry. See: Sentry #96584021.
+    if (err instanceof Error && "status" in err && err.status === 405) {
+      return new Response("Method Not Allowed", { status: 405 });
+    }
     Sentry.captureException(err);
     console.error("Unhandled error:", err);
     throw err;


### PR DESCRIPTION
## Summary

- Bots/scanners send requests with invalid percent-encoding (e.g. `/%c0`) which causes Fresh's router to throw `URIError` during `decodeURI()` in route matching — **before middleware can intercept**
- The existing middleware (both the URI validation and the URIError catch) couldn't prevent this because Fresh's router matches URLs before the middleware chain runs
- Fix: filter `URIError` events in Sentry's `beforeSend` so they're silently dropped instead of triggering alerts
- Removed the redundant middleware that was attempting (and failing) to catch this

## Root Cause

Fresh 2's `UrlPatternRouter.match()` calls `decodeURI(value)` on matched URL pattern groups at `router.ts:154`. This runs inside `App.fetch()` at `app.ts:405`, before any middleware handlers execute. There's no way to catch this from middleware.

Fixes Sentry #102617952